### PR TITLE
fix(场景联动#35057): 修复属性ID与列ID不匹配时的处理逻辑

### DIFF
--- a/views/Scene/Save/components/ParamsDropdown/Fulfill/Fulfill.vue
+++ b/views/Scene/Save/components/ParamsDropdown/Fulfill/Fulfill.vue
@@ -123,6 +123,7 @@ const showVisible = async () => {
   visible.value = true
   if (sceneStore.data.trigger.type === 'device') {
     const propertyId = props.column.split('.')[1]
+    const columnId = props.column.split('.')?.[props.column.split('.').length - 3]
     let resp
     if (sceneStore.data.trigger.device.selectorValues.length === 1 ) {
       resp = await detail(sceneStore.data.trigger.device.selectorValues[0].value)
@@ -133,7 +134,11 @@ const showVisible = async () => {
     if (resp.result.metadata) {
       const _metadata = JSON.parse(resp.result.metadata)
       const property = _metadata.properties?.find(item => item.id === propertyId)
-      run(property)
+      if(propertyId !== columnId ) {
+        run(property.valueType?.properties.find(item => item.id === columnId))
+      } else {
+        run(property)
+      }
     }
   }
 


### PR DESCRIPTION
在`showVisible`函数中，新增了`columnId`的提取逻辑，并在属性ID与列ID不匹配时，递归查找`property.valueType`中的属性。这解决了当属性嵌套时无法正确找到对应属性的问题。